### PR TITLE
Fix link to WFDB C package

### DIFF
--- a/software/c.md
+++ b/software/c.md
@@ -53,7 +53,7 @@ This will build the `libwfdb` library and install over 70 command-line tools.
 
 ## Repository and Contributions
 
-- **Source code**: [MIT-LCP/wfdb-app-toolbox](https://github.com/MIT-LCP/wfdb-app-toolbox)
+- **Source code**: [WFDB](https://github.com/bemoody/wfdb)
 - **Documentation**:
   - [WFDB Programmer's Guide](https://physionet.org/physiotools/wpg/)
   - [WFDB Applications Guide](https://physionet.org/physiotools/wag/)


### PR DESCRIPTION
The current link to the WFDB C package goes to a repository that no longer exists. This PR updates the link to the correct repository (as seen on WFDB Software Package page on PhysioNet). 