### PR TITLE
Make links to technical documentation prevalent

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -106,6 +106,6 @@ The physical measurement units (e.g., millivolts, mmHg) associated with a signal
 
 ---
 
-This glossary is intended to serve as a quick reference when working with WFDB-formatted data.  
+This site is intended to serve as a quick reference when working with WFDB-formatted data.  
 For full technical specifications, please refer to the [WFDB Programmer's Guide](https://physionet.org/physiotools/wpg/) and [WFDB Applications Guide](https://physionet.org/physiotools/wag/).
 

--- a/index.md
+++ b/index.md
@@ -39,6 +39,9 @@ Originally developed at MIT by **George B. Moody** in 1989, WFDB continues to ev
 - [Glossary](glossary)  
   Quick reference for key WFDB terms and concepts.
 
+This site is intended to serve as a quick reference when working with WFDB-formatted data.  
+For full technical specifications, please refer to the [WFDB Programmer's Guide](https://physionet.org/physiotools/wpg/) and [WFDB Applications Guide](https://physionet.org/physiotools/wag/).
+
 ---
 
 ## Get Involved


### PR DESCRIPTION
Since this site is a somewhat high level overview of the WFDB format, we should make it easy for users to find the detailed WFDB documentation. Previously, the links the Programmer and Application guides were only found at the bottom of the Glossary page. I've duplicated the reference to these documents on the Home page. I think it makes sense to keep the links in both locations on the site.