### PR TITLE
Improve and update `.hea` example

### DIFF
--- a/spec/header-files.md
+++ b/spec/header-files.md
@@ -43,27 +43,29 @@ The first non-comment line is the **record line**, which provides metadata about
 
 ### Examples
 
-#### Basic header (uniform sampling frequency)(record 100 from the [MIT-BIH database](https://www.physionet.org/content/mitdb)):
-
+**Basic header (uniform sampling frequency):**
+record 100 from the [MIT-BIH database](https://www.physionet.org/content/mitdb)
 ```text
 100 2 360 650000
 ```
+
 - `100`: Record name (must match the filename prefix).
 - `2`: Number of signals in the record.
 - `360`: Sampling frequency in Hz.
-- `650000`: Total samples for each signal.
+- `650000`: Number of samples for each signal.
 
-#### Multi-frequency header (unique sampling rates per channel):
+**Multi-frequency header (unique sampling rates per channel):**
 
 ```text
 12345 3 62.5 625 12:00:00 30/01/1989
 ```
+
 - `12345`: Record name (must match the filename prefix).
 - `3`: Number of signals in the record.
 - `62.5`: Sampling frequency in Hz.
-- `625`: Total frames for each signal. When `samps_per_frame` =  1 (default), this will be the total samples.
-- `12:00:00`: The time (`base_time`).
-- `30/01/1989`: The date (`base_date`).
+- `625`: Number of samples. For multi-frequency records this is the total frames for each signal.
+- `12:00:00`: Base time.
+- `30/01/1989`: Base date.
 
 ---
 
@@ -90,29 +92,32 @@ Each signal has its own line immediately following the record line (for single-s
 
 ### Examples
 
-#### Basic header (uniform sampling frequency)(record 100 from the [MIT-BIH database](https://www.physionet.org/content/mitdb)):
+**Basic header (uniform sampling frequency):**
+record 100 from the [MIT-BIH database](https://www.physionet.org/content/mitdb)
 ```text
 100.dat 212 200 11 1024 995 -22131 0 MLII
 100.dat 212 200 11 1024 1011 20052 0 V5
 ```
-- `100.dat`: Filename of the signal file.
-- `212`: Storage format (12-bit two's complement).
+
+- `100.dat`: File name of the signal file.
+- `212`: Format samples are stored in (12-bit two's complement).
 - `200`: ADC gain (i.e. number of digital values per physical unit). 
 - `11`: ADC resolution (bits).
 - `1024`: ADC zero value.
 - `995`, `1011`: Initial value.
 - `-22131`, `20052`: Checksum (sum of all signal samples modulo 2^16).
 - `0`: Block size.
-- `MLII`, `V5`: Signal labels (e.g., lead names).
+- `MLII`, `V5`: Description (e.g., signal lead names).
 
-#### Multi-frequency header (unique sampling rates per channel):
+**Multi-frequency header (unique sampling rates per channel):**
 ```text
 12345.dat 16x4 200/μV 12 0 0 2178 0 ECG
 12345.dat 16x2 16/mmHg 12 0 0 3497 0 ICP
 12345.dat 16x1 2500/Ohm 12 0 0 1366 0 RESP
 ```
-- `12345.dat`: Filename of the signal file.
-- `16`: Storage format (16-bit integers).
+
+- `12345.dat`: File name of the signal file.
+- `16`: Format samples are stored in (16-bit integers).
 - `x4`,`x2`,`x1`:  4, 2, and 1 samples per frame, respectively. This indicates that the ECG signal has `157 * 4 = 628` samples while the ICP signal has 314 samples and the RESP signal has 157 samples. 
 - `200/μV`, `16/mmHg`, `2500/Ohm`: ADC gain (i.e., number of digital values per physical unit).
 - `12`: ADC resolution (bits).
@@ -120,7 +125,7 @@ Each signal has its own line immediately following the record line (for single-s
 - `0`: Initial value.
 - `2178 `, `3497`, `1366`: Checksum (sum of all signal samples modulo 2^16).
 - `0`: Block size.
-- `ECG`, `ICP`, `RESP`: Signal labels (e.g., lead names).
+- `ECG`, `ICP`, `RESP`: Description (e.g., signal lead names).
 
 ---
 

--- a/spec/header-files.md
+++ b/spec/header-files.md
@@ -21,28 +21,35 @@ A header file contains:
 
 Each line must be under 255 characters, and fields are separated by spaces or tabs (except where otherwise noted).
 
+Detailed documentation on header files can be found at: [https://physionet.org/physiotools/wag/header-5.htm](https://physionet.org/physiotools/wag/header-5.htm)
+
 ---
 
 ## Record Line
 
 The first non-comment line is the **record line**, which provides metadata about the overall record. It includes:
 
-| Field | Description |
-|:------|:------------|
-| Record name | Identifier for the record (letters, digits, underscores only). |
-| Number of segments (optional) | If present, appended as `/n`. Indicates a multi-segment record. |
-| Number of signals | Number of signals described in the header. |
-| Sampling frequency (optional) | Samples per second per signal. Defaults to 250 if omitted. |
-| Counter frequency (optional) | Secondary clock frequency, separated from sampling frequency by a `/`. |
-| Base counter value (optional) | Offset value for counter, enclosed in parentheses. |
-| Number of samples (optional) | Total samples per signal. |
-| Base time (optional) | Start time of the recording (`HH:MM:SS`). |
-| Base date (optional) | Start date (`DD/MM/YYYY`). |
+| Field | Description                                                                |
+|:------|:---------------------------------------------------------------------------|
+| Record name | Identifier for the record (letters, digits, underscores only).             |
+| Number of segments (optional) | If present, appended as `/n`. Indicates a multi-segment record.            |
+| Number of signals | Number of signals described in the header.                                 |
+| Sampling frequency (optional) | Samples per second per signal. Defaults to 250 if omitted.                 |
+| Counter frequency (optional) | Secondary clock frequency, separated from sampling frequency by a `/`.     |
+| Base counter value (optional) | Offset value for counter, enclosed in parentheses.                         |
+| Number of samples (optional) | Total samples per signal when `samps_per_frame`=1; total frames otherwise. |
+| Base time (optional) | Start time of the recording (`HH:MM:SS`).                                  |
+| Base date (optional) | Start date (`DD/MM/YYYY`).                                                 |
 
 **Example:**
 ```text
-100 2 360 650000 12:00:00 01/01/2000
+12345 3 62.5 625 30/01/1989
 ```
+- `12345`: Record name (must match the filename prefix).
+- `3`: Number of signals in the record.
+- `62.5`: Sampling frequency in Hz.
+- `625`: Total frames for each signal. When `samps_per_frame` =  1 (default), this will be the total samples.
+- `30/01/1989`: The date (`base_date`).
 
 ---
 
@@ -69,9 +76,20 @@ Each signal has its own line immediately following the record line (for single-s
 
 **Example:**
 ```text
-100.dat 212 200 11 1024 995 0 MLII
-100.dat 212 200 11 1024 995 0 V5
+12345.dat 16x4 200/μV 12 0 0 2178 0 ECG
+12345.dat 16x2 16/mmHg 12 0 0 3497 0 ICP
+12345.dat 16x1 2500/Ohm 12 0 0 1366 0 RESP
 ```
+- `12345.dat`: Filename of the signal file.
+- `16`: Storage format (16-bit integers).
+- `x4`,`x2`,`x1`:  4, 2, and 1 samples per frame, respectively. This indicates that the ECG signal has `157 * 4 = 628` samples while the ICP signal has 314 samples and the RESP signal has 157 samples. 
+- `200/μV`, `16/mmHg`, `2500/Ohm`: ADC gain (i.e., number of digital values per physical unit).
+- `12`: ADC resolution (bits).
+- `0`: ADC zero value.
+- `0`: Initial value.
+- `2178 `, `3497`, `1366`: Checksum (sum of all signal samples modulo 2^16).
+- `0`: Block size.
+- `ECG`, `ICP`, `RESP`: Signal labels (e.g., lead names).
 
 ---
 

--- a/spec/header-files.md
+++ b/spec/header-files.md
@@ -29,26 +29,40 @@ Detailed documentation on header files can be found at: [https://physionet.org/p
 
 The first non-comment line is the **record line**, which provides metadata about the overall record. It includes:
 
-| Field | Description                                                                |
-|:------|:---------------------------------------------------------------------------|
-| Record name | Identifier for the record (letters, digits, underscores only).             |
-| Number of segments (optional) | If present, appended as `/n`. Indicates a multi-segment record.            |
-| Number of signals | Number of signals described in the header.                                 |
-| Sampling frequency (optional) | Samples per second per signal. Defaults to 250 if omitted.                 |
-| Counter frequency (optional) | Secondary clock frequency, separated from sampling frequency by a `/`.     |
-| Base counter value (optional) | Offset value for counter, enclosed in parentheses.                         |
+| Field | Description |
+|:------|:-----------|
+| Record name | Identifier for the record (letters, digits, underscores only). |
+| Number of segments (optional) | If present, appended as `/n`. Indicates a multi-segment record. |
+| Number of signals | Number of signals described in the header. |
+| Sampling frequency (optional) | Samples per second per signal. Defaults to 250 if omitted. |
+| Counter frequency (optional) | Secondary clock frequency, separated from sampling frequency by a `/`. |
+| Base counter value (optional) | Offset value for counter, enclosed in parentheses. |
 | Number of samples (optional) | Total samples per signal when `samps_per_frame`=1; total frames otherwise. |
-| Base time (optional) | Start time of the recording (`HH:MM:SS`).                                  |
-| Base date (optional) | Start date (`DD/MM/YYYY`).                                                 |
+| Base time (optional) | Start time of the recording (`HH:MM:SS`). |
+| Base date (optional) | Start date (`DD/MM/YYYY`). |
 
-**Example:**
+### Examples
+
+#### Basic header (uniform sampling frequency)(record 100 from the [MIT-BIH database](https://www.physionet.org/content/mitdb)):
+
 ```text
-12345 3 62.5 625 30/01/1989
+100 2 360 650000
+```
+- `100`: Record name (must match the filename prefix).
+- `2`: Number of signals in the record.
+- `360`: Sampling frequency in Hz.
+- `650000`: Total samples for each signal.
+
+#### Multi-frequency header (unique sampling rates per channel):
+
+```text
+12345 3 62.5 625 12:00:00 30/01/1989
 ```
 - `12345`: Record name (must match the filename prefix).
 - `3`: Number of signals in the record.
 - `62.5`: Sampling frequency in Hz.
 - `625`: Total frames for each signal. When `samps_per_frame` =  1 (default), this will be the total samples.
+- `12:00:00`: The time (`base_time`).
 - `30/01/1989`: The date (`base_date`).
 
 ---
@@ -74,7 +88,24 @@ Each signal has its own line immediately following the record line (for single-s
 | Block size (optional) | Number of samples per block (for formats supporting block I/O). |
 | Description (optional) | Free-text description of the signal (e.g., lead name `ECG Lead II`). |
 
-**Example:**
+### Examples
+
+#### Basic header (uniform sampling frequency)(record 100 from the [MIT-BIH database](https://www.physionet.org/content/mitdb)):
+```text
+100.dat 212 200 11 1024 995 -22131 0 MLII
+100.dat 212 200 11 1024 1011 20052 0 V5
+```
+- `100.dat`: Filename of the signal file.
+- `212`: Storage format (12-bit two's complement).
+- `200`: ADC gain (i.e. number of digital values per physical unit). 
+- `11`: ADC resolution (bits).
+- `1024`: ADC zero value.
+- `995`, `1011`: Initial value.
+- `-22131`, `20052`: Checksum (sum of all signal samples modulo 2^16).
+- `0`: Block size.
+- `MLII`, `V5`: Signal labels (e.g., lead names).
+
+#### Multi-frequency header (unique sampling rates per channel):
 ```text
 12345.dat 16x4 200/μV 12 0 0 2178 0 ECG
 12345.dat 16x2 16/mmHg 12 0 0 3497 0 ICP
@@ -105,4 +136,5 @@ Each signal has its own line immediately following the record line (for single-s
 
 - A header file may describe signals stored in multiple files or multiple signals in a single file.
 - Fields like sampling frequency, counter frequency, and base time/date improve time-aligned analysis but are optional.
+- Storage format options and details can be found at: [https://physionet.org/physiotools/wag/signal-5.htm](https://physionet.org/physiotools/wag/signal-5.htm)
 - Multi-segment records use a slightly different structure (described separately).


### PR DESCRIPTION
This PR improves the `.hea` examples by adding descriptions for each element from a header line. It also updates the example header lines to show a multi-frequency record. This gives users additional insight into how frames, samples per frame, and total samples can be garnered from the `.hea`. 

I've also added a reference to the detailed header documentation for easy reference. 